### PR TITLE
Updated to ignore Mermaid diagrams

### DIFF
--- a/es5/markdown-parser.js
+++ b/es5/markdown-parser.js
@@ -18,7 +18,8 @@ exports.default = function (src) {
     tracker.replaceAll(jekyllFrontMatter, " ");
   }
 
-  tracker.replaceAll(/\<div class=\"[Mm]ermaid\".*\<\/div\>/s, " "); // ignore Mermaid diagramstracker.removeAll(/```[\w\W]*?```/);
+  tracker.replaceAll(/\<div class=\"[Mm]ermaid\".*\<\/div\>/s, " "); // ignore Mermaid diagrams
+  tracker.removeAll(/```[\w\W]*?```/);
   tracker.removeAll(/~~~[\w\W]*?~~~/);
   tracker.removeAll(/``[\w\W]*?``/);
   tracker.removeAll(/`[^`]*`/);

--- a/es5/markdown-parser.js
+++ b/es5/markdown-parser.js
@@ -18,7 +18,7 @@ exports.default = function (src) {
     tracker.replaceAll(jekyllFrontMatter, " ");
   }
 
-  tracker.removeAll(/```[\w\W]*?```/);
+  tracker.replaceAll(/\<div class=\"[Mm]ermaid\".*\<\/div\>/s, " "); // ignore Mermaid diagramstracker.removeAll(/```[\w\W]*?```/);
   tracker.removeAll(/~~~[\w\W]*?~~~/);
   tracker.removeAll(/``[\w\W]*?``/);
   tracker.removeAll(/`[^`]*`/);

--- a/es6/markdown-parser.js
+++ b/es6/markdown-parser.js
@@ -16,6 +16,7 @@ export default function(src) {
     tracker.replaceAll(jekyllFrontMatter, " ");
   }
 
+  tracker.replaceAll(/\<div class=\"[Mm]ermaid\".*\<\/div\>/s, " "); // ignore Mermaid diagrams
   tracker.removeAll(/```[\w\W]*?```/);
   tracker.removeAll(/~~~[\w\W]*?~~~/);
   tracker.removeAll(/``[\w\W]*?``/);


### PR DESCRIPTION
I've updated so that the following text blocks are ignored:
```
<div class="Mermaid">
[Mermaid Diagram Definition...]
</div>
```